### PR TITLE
*: Add Consistency option to drive select query

### DIFF
--- a/backend/replication/db_test.go
+++ b/backend/replication/db_test.go
@@ -21,6 +21,7 @@ func TestPickDB(t *testing.T) {
 	tests := []struct {
 		name  string
 		query string
+		args  []interface{}
 		db    *db
 		want  sql.DB
 	}{
@@ -34,7 +35,6 @@ func TestPickDB(t *testing.T) {
 			},
 			want: &db1,
 		},
-
 		{
 			name:  "update",
 			query: "foo",
@@ -45,11 +45,22 @@ func TestPickDB(t *testing.T) {
 			},
 			want: &db0,
 		},
+		{
+			name:  "strongly consistent",
+			query: "foo",
+			args: []interface{}{sql.StronglyConsistent},
+			db: &db{
+				DB:     &db0,
+				slave:  &db1,
+				parser: mockParser(map[string]sqlparser.StmtType{"foo": sqlparser.StmtSelect}),
+			},
+			want: &db0,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.db.pickDB(tt.query); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.db.pickDB(tt.query, tt.args); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("db.pickDB() = %v, want %v", got, tt.want)
 			}
 		})

--- a/backend/simple/db.go
+++ b/backend/simple/db.go
@@ -74,7 +74,7 @@ func (tx *tx) Exec(ctx context.Context, qry string, vs ...interface{}) (sql.Resu
 	case tx.ch <- struct{}{}:
 	}
 
-	res, err := tx.q.ExecContext(ctx, qry, sql.StripReturningFields(vs)...)
+	res, err := tx.q.ExecContext(ctx, qry, sql.StripOptions(vs)...)
 	<-tx.ch
 
 	return res, err

--- a/backend/simple/queryer.go
+++ b/backend/simple/queryer.go
@@ -18,7 +18,7 @@ type queryer struct {
 }
 
 func (q *queryer) Exec(ctx context.Context, qry string, vs ...interface{}) (sql.Result, error) {
-	return q.ExecContext(ctx, qry, sql.StripReturningFields(vs)...)
+	return q.ExecContext(ctx, qry, sql.StripOptions(vs)...)
 }
 
 func (q *queryer) QueryRow(ctx context.Context, qry string, vs ...interface{}) sql.Scanner {

--- a/backend/sqlite3/db.go
+++ b/backend/sqlite3/db.go
@@ -116,7 +116,7 @@ func (q *queryer) rewrite(stmt string, vs []interface{}) (string, []interface{},
 		i int
 	)
 
-	vs = sql.StripReturningFields(vs)
+	vs = sql.StripOptions(vs)
 
 	rstmt := argRegexp.ReplaceAllStringFunc(stmt, func(frag string) string {
 		v, err := strconv.Atoi(strings.TrimPrefix(frag, "$"))

--- a/db.go
+++ b/db.go
@@ -18,6 +18,10 @@ var (
 	ErrTxDone   = sql.ErrTxDone
 )
 
+type Option interface {
+	IsSQLOption()
+}
+
 type Scanner interface {
 	Scan(...interface{}) error
 }
@@ -39,11 +43,21 @@ type Returning struct {
 	Field string
 }
 
-func StripReturningFields(vs []interface{}) []interface{} {
+func (Returning) IsSQLOption() {}
+
+type Consistency uint8
+func (Consistency) IsSQLOption() {}
+
+const (
+	EventuallyConsistent Consistency = iota
+	StronglyConsistent
+)
+
+func StripOptions(vs []interface{}) []interface{} {
 	var res []interface{}
 
 	for _, v := range vs {
-		if _, ok := v.(*Returning); !ok {
+		if _, ok := v.(Option); !ok {
 			res = append(res, v)
 		}
 	}

--- a/x/sqlbuilder/select_statement.go
+++ b/x/sqlbuilder/select_statement.go
@@ -2,6 +2,8 @@ package sqlbuilder
 
 import (
 	"fmt"
+
+	"github.com/upfluence/sql"
 )
 
 type NullableInt struct {
@@ -21,6 +23,8 @@ type SelectStatement struct {
 
 	Offset NullableInt
 	Limit  NullableInt
+
+	Consistency sql.Consistency
 }
 
 func (ss SelectStatement) Clone() SelectStatement {
@@ -34,6 +38,7 @@ func (ss SelectStatement) Clone() SelectStatement {
 		HavingClause:   clonePredicateClause(ss.HavingClause),
 		Offset:         ss.Offset,
 		Limit:          ss.Limit,
+		Consistency:	ss.Consistency,
 	}
 }
 
@@ -112,6 +117,10 @@ func (ss SelectStatement) buildQuery(vs map[string]interface{}) (string, []inter
 
 	if ss.Offset.Valid {
 		fmt.Fprintf(&qw, " OFFSET %d", ss.Offset.Int)
+	}
+
+	if ss.Consistency != sql.EventuallyConsistent {
+		qw.vs = append(qw.vs, ss.Consistency)
 	}
 
 	return qw.String(), qw.vs, bindings, nil

--- a/x/sqlbuilder/select_statement_test.go
+++ b/x/sqlbuilder/select_statement_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/upfluence/sql"
 	"github.com/upfluence/sql/backend/static"
 )
 
@@ -62,7 +63,7 @@ func TestSelectQuery(t *testing.T) {
 				Table:         "foo",
 				SelectClauses: []Marker{Column("biz"), Column("buz")},
 				JoinClauses: []JoinClause{
-					JoinClause{
+					{
 						Table: "bar",
 						Type:  InnerJoin,
 						WhereClause: EqMarkers(
@@ -266,12 +267,24 @@ func TestSelectQuery(t *testing.T) {
 				SelectClauses: []Marker{Column("bar")},
 				WhereClause:   StaticEq(Column("bar"), "buz"),
 				OrderByClauses: []OrderByClause{
-					OrderByClause{Field: Column("bar")},
-					OrderByClause{Field: Column("buz"), Direction: Desc},
+					{Field: Column("bar")},
+					{Field: Column("buz"), Direction: Desc},
 				},
 			},
 			stmt: "SELECT bar FROM foo WHERE bar = $1 ORDER BY bar, buz DESC",
 			args: []interface{}{"buz"},
+		},
+		{
+			name: "consistency",
+			ss: SelectStatement{
+				Table:         "foo",
+				SelectClauses: []Marker{Column("bar")},
+				WhereClause:   StaticEq(Column("bar"), "buz"),
+				Consistency:   sql.StronglyConsistent,
+			},
+			stmt: "SELECT bar FROM foo WHERE bar = $1",
+			vs:   map[string]interface{}{"bar": []int64{}},
+			args: []interface{}{"buz", sql.StronglyConsistent},
 		},
 		{
 			name: "error no marker",


### PR DESCRIPTION
The idea is to add an option to force the consistency of the data return of an select query. By default the consistency is `EventuallyConsistent` with is the previous behavior. By setting the consistency to `StronglyConsistent` this will force the use of master db in the replication backend and ensure to receive up to date data.