### PR TITLE
backend/replication: forceMaster should take and array of interface

### DIFF
--- a/backend/replication/db.go
+++ b/backend/replication/db.go
@@ -34,7 +34,7 @@ func (d *db) Query(ctx context.Context, q string, vs ...interface{}) (sql.Cursor
 	return d.pickDB(q, vs).Query(ctx, q, vs...)
 }
 
-func forceMaster(vs ...interface{}) bool {
+func forceMaster(vs []interface{}) bool {
 	for _, v := range vs {
 		if c, ok := v.(sql.Consistency); ok && c == sql.StronglyConsistent {
 			return true


### PR DESCRIPTION
### What does this PR do?

Fix the forceMaster methode which should get an array of interface 

### What are the observable changes?

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
