### PR TITLE
x/sqlbuilder/reader: Add consistency option to the ReadOptions

### DIFF
--- a/x/sqlbuilder/reader/reader.go
+++ b/x/sqlbuilder/reader/reader.go
@@ -21,6 +21,8 @@ type ReadOptions struct {
 
 	SkipPagination bool
 	SkipOrdering   bool
+
+	Consistency sql.Consistency
 }
 
 type Reader interface {
@@ -80,6 +82,7 @@ func (r reader) Read(ctx context.Context, opts ReadOptions) (sqlbuilder.Cursor, 
 		GroupByClause: opts.GroupByClause,
 		HavingClause:  opts.HavingClause,
 		WhereClause:   r.pr.reducer()(r.pr.predicateClauses()...),
+		Consistency:   opts.Consistency,
 	}
 
 	if p := r.pr.pagination(); !opts.SkipPagination && p != zeroPagination {


### PR DESCRIPTION
### What does this PR do?

Allow the `reader.Reader` user to specify a consistency level to the lower layer of the SQL library

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
