### PR TITLE
sqlutil: Add public API to register driver wrapper

### DIFF
--- a/sqlutil/open_cgo.go
+++ b/sqlutil/open_cgo.go
@@ -9,9 +9,7 @@ import (
 )
 
 func init() {
-	driverWrapperMu.Lock()
-	driverWrapper["sqlite3"] = newSQLite3DB
-	driverWrapperMu.Unlock()
+	RegisterDriverWrapper("sqlite3", newSQLite3DB)
 }
 
 func newSQLite3DB(db sql.DB, _ sqlparser.SQLParser) sql.DB {

--- a/sqlutil/open_test.go
+++ b/sqlutil/open_test.go
@@ -1,13 +1,31 @@
 package sqlutil
 
 import (
+	"database/sql"
 	"testing"
+
+	"github.com/lib/pq"
 
 	"github.com/upfluence/sql/backend/postgres"
 )
 
 func TestOpenPostgresDB(t *testing.T) {
 	db, err := Open(WithMaster("postgres", "foobar"))
+
+	if err != nil {
+		t.Errorf("Open() = (_, %+v) wanted nil", err)
+	}
+
+	if !postgres.IsPostgresDB(db) {
+		t.Errorf("invalid wrapping of the DB")
+	}
+}
+
+func TestRegisterDriverWrapper(t *testing.T) {
+	sql.Register("bizbuz", &pq.Driver{})
+	RegisterDriverWrapper("bizbuz", postgres.NewDB)
+
+	db, err := Open(WithMaster("bizbuz", "foobar"))
 
 	if err != nil {
 		t.Errorf("Open() = (_, %+v) wanted nil", err)

--- a/x/migration/driver_test.go
+++ b/x/migration/driver_test.go
@@ -1,0 +1,19 @@
+package migration
+
+import "testing"
+
+func TestRegisterDriver(t *testing.T) {
+	d := fetchDriver("foo")
+
+	if n := d.Name(); n != "default" {
+		t.Errorf("driver.Name() = %q [ want: default ]", n)
+	}
+
+	RegisterDriver("foo", PostgresDriver)
+
+	d = fetchDriver("foo")
+
+	if n := d.Name(); n != "postgres" {
+		t.Errorf("driver.Name() = %q [ want: postgres ]", n)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

In order to deal with DB system specific features we have couple of sql.DB "wrappers" that would adjust the syntax of the query as well as the format of the responses to match a unified interface.

In case of UDS to acheive lazy and  recurrent secrets and endpoint discovery we use a custom database driver that wraps the postgres one.

By making `RegisterDriverWrapper` public it will allow us to use the postgres wrpaper to rewrite the queries.

Fixes https://sentry.io/organizations/upfluence/issues/2373176062/?project=5709406&query=is%3Aunresolved

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

Storing stuff in a global variable does not really appeal to me but this progress has to be analog to the https://golang.org/pkg/database/sql/#Register api