### PR TITLE
Fix utc time location

### DIFF
--- a/sqltypes/null_utc_time.go
+++ b/sqltypes/null_utc_time.go
@@ -19,7 +19,7 @@ func (nut *NullUTCTime) Scan(v interface{}) error {
 	}
 
 	nut.Valid = nt.Valid
-	nut.Time = time.Unix(nt.Time.UTC().Unix(), 0)
+	nut.Time = time.Unix(nt.Time.UTC().Unix(), 0).UTC()
 
 	return nil
 }

--- a/sqltypes/null_utc_time_test.go
+++ b/sqltypes/null_utc_time_test.go
@@ -45,7 +45,7 @@ func TestNullUTCTime_Scan(t *testing.T) {
 			var n = NullUTCTime{}
 
 			tt.errFn(t, n.Scan(tt.value))
-			assert.Equal(t, tt.want.Unix(), n.Time.Unix())
+			assert.Equal(t, tt.want, n.Time)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Make sure the time returned carry the UTC location and not the Local

Fixes none

### What are the observable changes?

Force UTC location when scanning with the NullUTCTime

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

We should be able to assert utc time stored in db correctly.