### PR TITLE
x/sqlbuilder: Add Not to the predicate clause API

### DIFF
--- a/x/sqlbuilder/select_statement_test.go
+++ b/x/sqlbuilder/select_statement_test.go
@@ -250,6 +250,24 @@ func TestSelectQuery(t *testing.T) {
 			stmt: "SELECT bar FROM foo WHERE bar IS NOT NULL",
 		},
 		{
+			name: "not is null",
+			ss: SelectStatement{
+				Table:         "foo",
+				SelectClauses: []Marker{Column("bar")},
+				WhereClause:   Not(IsNull(Column("bar"))),
+			},
+			stmt: "SELECT bar FROM foo WHERE NOT (bar IS NULL)",
+		},
+		{
+			name: "stable by not not",
+			ss: SelectStatement{
+				Table:         "foo",
+				SelectClauses: []Marker{Column("bar")},
+				WhereClause:   Not(Not(IsNull(Column("bar")))),
+			},
+			stmt: "SELECT bar FROM foo WHERE bar IS NULL",
+		},
+		{
 			name: "order by",
 			ss: SelectStatement{
 				Table:          "foo",


### PR DESCRIPTION
### What does this PR do?

This PR add the API `sqlbuilder.Not` to wrap `PredicateClause`.  If the sub predicate clause implement `interface{ Not() PredicateClause })` it will use and allow syntax optimizaiton.

⚠️  This PR does not include implementation of the `Not` for the existing predicate clauses.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
