### PR TITLE
backend/postgres: Add SSLMode knob in the postgres config

### DIFF
--- a/backend/postgres/config_test.go
+++ b/backend/postgres/config_test.go
@@ -1,0 +1,24 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDSN(t *testing.T) {
+	for _, tt := range []struct {
+		c   Config
+		dsn string
+	}{
+		{
+			c:   Config{DBName: "foobar", SSLMode: VerifyFull},
+			dsn: "postgres://localhost:5432/foobar?sslmode=verify-full",
+		},
+	} {
+		dsn, err := tt.c.DSN()
+
+		assert.NoError(t, err)
+		assert.Equal(t, tt.dsn, dsn)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

As of right now our SSL mode for postgres dsn is binary, either verify-ca or disabled. There is a few more mode that could be useful.

In order to keep the code retrocompatible, i added a SSLMode attribute on the config struct and if it is not set, it will default to the previous behavour.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
