### PR TITLE
sqlutil: Default all connection to a max of 128 open conns

### DIFF
--- a/sqlutil/open.go
+++ b/sqlutil/open.go
@@ -17,7 +17,7 @@ import (
 var (
 	defaultOptions = &builder{
 		parser:  sqlparser.DefaultSQLParser(),
-		options: []DBOption{WithMaxOpenConns(1 << 7)},
+		options: []DBOption{WithMaxOpenConns(128)},
 	}
 
 	ErrNoDBProvided = errors.New("sql/sqlutil: No DB provided")

--- a/sqlutil/open.go
+++ b/sqlutil/open.go
@@ -15,7 +15,10 @@ import (
 )
 
 var (
-	defaultOptions = &builder{parser: sqlparser.DefaultSQLParser()}
+	defaultOptions = &builder{
+		parser:  sqlparser.DefaultSQLParser(),
+		options: []DBOption{WithMaxOpenConns(1 << 7)},
+	}
 
 	ErrNoDBProvided = errors.New("sql/sqlutil: No DB provided")
 
@@ -119,6 +122,10 @@ func (b *builder) buildDB() (sql.DB, error) {
 	var masters, slaves []sql.DB
 
 	for _, i := range b.dbs {
+		for _, opt := range b.options {
+			opt(i)
+		}
+
 		db, err := i.buildDB(b.parser)
 
 		if err != nil {
@@ -146,6 +153,7 @@ func (b *builder) buildDB() (sql.DB, error) {
 type builder struct {
 	dbs         []*dbInput
 	middlewares []sql.MiddlewareFactory
+	options     []DBOption
 
 	parser sqlparser.SQLParser
 }
@@ -160,6 +168,10 @@ func WithDatabase(driver, dsn string, readOnly bool, opts ...DBOption) Option {
 	}
 
 	return func(b *builder) { b.dbs = append(b.dbs, &i) }
+}
+
+func WithGlobalDBOptions(opts ...DBOption) Option {
+	return func(b *builder) { b.options = append(b.options, opts...) }
 }
 
 func WithMaster(driver, dsn string, opts ...DBOption) Option {


### PR DESCRIPTION
### What does this PR do?

This PR add a handy little preset for sql DB building. It will limit by default the number of open conn  to 128.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
