### PR TITLE
*: Add Isolation option in the BeginTx API.

### DIFF
--- a/backend/balancer/db.go
+++ b/backend/balancer/db.go
@@ -25,14 +25,14 @@ type db struct {
 
 func (d *db) Driver() string { return d.driver }
 
-func (d *db) BeginTx(ctx context.Context) (sql.Tx, error) {
+func (d *db) BeginTx(ctx context.Context, opts sql.TxOptions) (sql.Tx, error) {
 	db, cfn, err := d.b.Get(ctx)
 
 	if err != nil {
 		return nil, err
 	}
 
-	subTx, err := db.BeginTx(ctx)
+	subTx, err := db.BeginTx(ctx, opts)
 
 	if err != nil {
 		return nil, err

--- a/backend/postgres/db.go
+++ b/backend/postgres/db.go
@@ -23,8 +23,8 @@ func NewDB(d sql.DB, p sqlparser.SQLParser) sql.DB {
 
 func (db *db) Driver() string { return db.db.Driver() }
 
-func (db *db) BeginTx(ctx context.Context) (sql.Tx, error) {
-	cur, err := db.db.BeginTx(ctx)
+func (db *db) BeginTx(ctx context.Context, opts sql.TxOptions) (sql.Tx, error) {
+	cur, err := db.db.BeginTx(ctx, opts)
 
 	if err != nil {
 		return nil, err

--- a/backend/postgres/db_test.go
+++ b/backend/postgres/db_test.go
@@ -90,7 +90,7 @@ func TestExec(t *testing.T) {
 
 func TestTxExec(t *testing.T) {
 	testQueryer(t, func(db sql.DB) sql.Queryer {
-		tx, err := db.BeginTx(context.Background())
+		tx, err := db.BeginTx(context.Background(), sql.TxOptions{})
 
 		if err != nil {
 			t.Fatalf("db.BeginTx() = %v, want: nil", err)

--- a/backend/simple/db.go
+++ b/backend/simple/db.go
@@ -149,8 +149,11 @@ func (tx *tx) Query(ctx context.Context, qry string, vs ...interface{}) (sql.Cur
 
 func (d *db) Driver() string { return d.driver }
 
-func (d *db) BeginTx(ctx context.Context) (sql.Tx, error) {
-	t, err := d.db.BeginTx(ctx, nil)
+func (d *db) BeginTx(ctx context.Context, opts sql.TxOptions) (sql.Tx, error) {
+	t, err := d.db.BeginTx(
+		ctx,
+		&stdsql.TxOptions{Isolation: stdsql.IsolationLevel(opts.Isolation)},
+	)
 
 	if err != nil {
 		return nil, err

--- a/backend/sqlite3/db.go
+++ b/backend/sqlite3/db.go
@@ -28,8 +28,8 @@ func NewDB(d sql.DB) sql.DB {
 	return &db{queryer: &queryer{q: d}, db: d}
 }
 
-func (db *db) BeginTx(ctx context.Context) (sql.Tx, error) {
-	dtx, err := db.db.BeginTx(ctx)
+func (db *db) BeginTx(ctx context.Context, opts sql.TxOptions) (sql.Tx, error) {
+	dtx, err := db.db.BeginTx(ctx, opts)
 
 	if err != nil {
 		return nil, err

--- a/backend/static/db.go
+++ b/backend/static/db.go
@@ -58,8 +58,11 @@ type Tx struct {
 func (tx *Tx) Commit() error   { return tx.CommitErr }
 func (tx *Tx) Rollback() error { return tx.RollbackErr }
 
-func (db *DB) Driver() string                          { return "sqltest" }
-func (db *DB) BeginTx(context.Context) (sql.Tx, error) { return db.Tx, db.TxErr }
+func (db *DB) Driver() string { return "sqltest" }
+
+func (db *DB) BeginTx(context.Context, sql.TxOptions) (sql.Tx, error) {
+	return db.Tx, db.TxErr
+}
 
 func (q *Queryer) Exec(_ context.Context, stmt string, args ...interface{}) (sql.Result, error) {
 	q.ExecQueries = append(q.ExecQueries, Query{stmt, args})

--- a/db.go
+++ b/db.go
@@ -6,7 +6,8 @@ import (
 )
 
 type (
-	Result     = sql.Result
+	Result = sql.Result
+
 	NullInt64  = sql.NullInt64
 	NullString = sql.NullString
 	NullBool   = sql.NullBool
@@ -35,8 +36,12 @@ type Queryer interface {
 type DB interface {
 	Queryer
 
-	BeginTx(context.Context) (Tx, error)
+	BeginTx(context.Context, TxOptions) (Tx, error)
 	Driver() string
+}
+
+type TxOptions struct {
+	Isolation IsolationLevel
 }
 
 type Returning struct {
@@ -46,6 +51,7 @@ type Returning struct {
 func (Returning) IsSQLOption() {}
 
 type Consistency uint8
+
 func (Consistency) IsSQLOption() {}
 
 const (

--- a/integration/concurrent_tx_test.go
+++ b/integration/concurrent_tx_test.go
@@ -28,7 +28,7 @@ func TestConcurrentTxQuery(t *testing.T) {
 	).Run(t, func(t *testing.T, db sql.DB) {
 		var (
 			ctx     = context.Background()
-			tx, err = db.BeginTx(ctx)
+			tx, err = db.BeginTx(ctx, sql.TxOptions{})
 			k       = 100
 
 			wg sync.WaitGroup

--- a/middleware/logger/middleware.go
+++ b/middleware/logger/middleware.go
@@ -85,8 +85,8 @@ type db struct {
 
 func (d *db) Driver() string { return d.db.Driver() }
 
-func (d *db) BeginTx(ctx context.Context) (sql.Tx, error) {
-	var t, err = d.db.BeginTx(ctx)
+func (d *db) BeginTx(ctx context.Context, opts sql.TxOptions) (sql.Tx, error) {
+	var t, err = d.db.BeginTx(ctx, opts)
 
 	if err != nil {
 		return nil, err

--- a/tx.go
+++ b/tx.go
@@ -2,10 +2,24 @@ package sql
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 )
 
+type IsolationLevel = sql.IsolationLevel
+
 var ErrRollback = errors.New("sql: rollback sentinel")
+
+const (
+	LevelDefault IsolationLevel = iota
+	LevelReadUncommitted
+	LevelReadCommitted
+	LevelWriteCommitted
+	LevelRepeatableRead
+	LevelSnapshot
+	LevelSerializable
+	LevelLinearizable
+)
 
 type Tx interface {
 	Queryer
@@ -16,8 +30,8 @@ type Tx interface {
 
 type QueryerFunc func(Queryer) error
 
-func ExecuteTx(ctx context.Context, db DB, fn QueryerFunc) error {
-	tx, err := db.BeginTx(ctx)
+func ExecuteTx(ctx context.Context, db DB, opts TxOptions, fn QueryerFunc) error {
+	tx, err := db.BeginTx(ctx, opts)
 
 	if err != nil {
 		return err

--- a/x/migration/migration.go
+++ b/x/migration/migration.go
@@ -161,7 +161,7 @@ func (m *migrator) upOne(ctx context.Context) (bool, error) {
 }
 
 func (m *migrator) executeTx(ctx context.Context, fn func(sql.Queryer) error) error {
-	tx, err := m.BeginTx(ctx)
+	tx, err := m.BeginTx(ctx, sql.TxOptions{})
 
 	if err != nil {
 		return errors.Wrap(err, "can not open tx")

--- a/x/migration/migration.go
+++ b/x/migration/migration.go
@@ -161,7 +161,9 @@ func (m *migrator) upOne(ctx context.Context) (bool, error) {
 }
 
 func (m *migrator) executeTx(ctx context.Context, fn func(sql.Queryer) error) error {
-	tx, err := m.BeginTx(ctx, sql.TxOptions{})
+	// Isolation level serializable will avoid having multiple migration to be
+	// executed at the same time.
+	tx, err := m.BeginTx(ctx, sql.TxOptions{Isolation: sql.LevelSerializable})
 
 	if err != nil {
 		return errors.Wrap(err, "can not open tx")

--- a/x/sqlbuilder/upserter/upserter.go
+++ b/x/sqlbuilder/upserter/upserter.go
@@ -31,7 +31,7 @@ type Upserter struct {
 }
 
 func (u *Upserter) executeTx(ctx context.Context, fn func(sql.Queryer) error) error {
-	return sql.ExecuteTx(ctx, u, fn)
+	return sql.ExecuteTx(ctx, u, sql.TxOptions{}, fn)
 }
 
 func (u *Upserter) PrepareUpsert(stmt Statement) sqlbuilder.Execer {

--- a/x/sqlbuilder/upserter/upserter.go
+++ b/x/sqlbuilder/upserter/upserter.go
@@ -31,7 +31,14 @@ type Upserter struct {
 }
 
 func (u *Upserter) executeTx(ctx context.Context, fn func(sql.Queryer) error) error {
-	return sql.ExecuteTx(ctx, u, sql.TxOptions{}, fn)
+	return sql.ExecuteTx(
+		ctx,
+		u,
+		// In order to avoid concurrent insert for the same "query values",
+		// isolation level "serializable" is needed
+		sql.TxOptions{Isolation: sql.LevelSerializable},
+		fn,
+	)
 }
 
 func (u *Upserter) PrepareUpsert(stmt Statement) sqlbuilder.Execer {


### PR DESCRIPTION
### What does this PR do?

Related to: https://github.com/upfluence/backlog/issues/1096

This PR adds support for options in the `BeginTx` call.  Especially the isolation option.

⚠️ it breaks the BC of the sql.DB API.

The isolation `Serializable` has been used in:

* upserter to avoid concurrent insert (cf. linked bug)
* migration to avoid concurrent migration execution

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
