### PR TITLE
x/sqlbuilder/upserter: Add Mode for Insert Only call to the Upserter

### DIFF
--- a/x/sqlbuilder/upserter/upserter.go
+++ b/x/sqlbuilder/upserter/upserter.go
@@ -15,6 +15,15 @@ var (
 	oneMarker = sqlbuilder.SQLExpression("one", "1")
 )
 
+const (
+	Insert Mode = 1 << iota
+	Update
+
+	Upsert = Insert | Update
+)
+
+type Mode uint8
+
 type Statement struct {
 	Table string
 
@@ -23,6 +32,16 @@ type Statement struct {
 	SetValues    []sqlbuilder.Marker
 
 	Returning *sql.Returning
+
+	Mode Mode
+}
+
+func (s Statement) mode() Mode {
+	if s.Mode == 0 {
+		return Upsert
+	}
+
+	return s.Mode
 }
 
 type UpsertStatement = Statement


### PR DESCRIPTION
### What does this PR do?

This PR adds the support for Insert Only calls to the upserter. 

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
