### PR TITLE
Add serialyser in JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.18.x' ]
+        go: [ '1.18.x', '1.17.x', '1.16.x' ]
     services:
       postgres:
         image: postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16.x', '1.15.x', '1.14.x' ]
+        go: [ '1.18.x' ]
     services:
       postgres:
         image: postgres

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
       - name: Check out code
         uses: actions/checkout@v1
       - name: golanci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upfluence/sql
 
-go 1.16
+go 1.18
 
 require (
 	github.com/lib/pq v1.4.0
@@ -8,4 +8,10 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/upfluence/errors v0.2.2
 	github.com/upfluence/log v0.0.4
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
 )

--- a/sqltypes/json.go
+++ b/sqltypes/json.go
@@ -1,0 +1,35 @@
+package sqltypes
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+
+	"github.com/upfluence/errors"
+)
+
+type JSONValue[T any] struct {
+	Data  T
+	Valid bool
+}
+
+func (jv *JSONValue[T]) Scan(v interface{}) error {
+	switch vv := v.(type) {
+	case []byte:
+		return json.Unmarshal(vv, &jv.Data)
+	case string:
+		return json.Unmarshal([]byte(vv), &jv.Data)
+	case nil:
+		jv.Data = *new(T)
+		return nil
+	default:
+		return errors.Wrap(errInvalidType, "expecting a byte slice or string")
+	}
+}
+
+func (jv JSONValue[T]) Value() (driver.Value, error) {
+	if !jv.Valid {
+		return nil, nil
+	}
+
+	return json.Marshal(jv.Data)
+}

--- a/sqltypes/json_test.go
+++ b/sqltypes/json_test.go
@@ -1,0 +1,107 @@
+package sqltypes
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/upfluence/errors/errtest"
+)
+
+type testPayload struct {
+	Key string `json:"key"`
+}
+
+func TestScan(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		value   any
+		want    testPayload
+		wantErr errtest.ErrorAssertion
+	}{
+		{
+			name:    "wrong value type",
+			value:   1,
+			wantErr: errtest.ErrorCause(errInvalidType),
+		},
+		{
+			name:  "invalid json",
+			value: "test",
+			wantErr: errtest.ErrorAssertionFunc(
+				func(tb testing.TB, err error) {
+					assert.IsType(t, &json.SyntaxError{}, err)
+				},
+			),
+		},
+		{
+			name:    "nil",
+			want:    testPayload{},
+			wantErr: errtest.NoError(),
+		},
+		{
+			name:    "success",
+			value:   `{"key":"foo"}`,
+			want:    testPayload{Key: "foo"},
+			wantErr: errtest.NoError(),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var jv JSONValue[testPayload]
+
+			err := jv.Scan(tt.value)
+			tt.wantErr.Assert(t, err)
+			assert.Equal(t, tt.want, jv.Data)
+		})
+	}
+}
+
+func TestValue(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		value   driver.Valuer
+		want    any
+		wantErr error
+	}{
+		{
+			name: "invalid data",
+			value: JSONValue[testPayload]{
+				Data: testPayload{},
+			},
+		},
+		{
+			name: "string",
+			value: JSONValue[string]{
+				Data:  "test",
+				Valid: true,
+			},
+			want: []byte(`"test"`),
+		},
+		{
+			name: "number",
+			value: JSONValue[int64]{
+				Data:  1,
+				Valid: true,
+			},
+			want: []byte(`1`),
+		},
+		{
+			name: "object",
+			value: JSONValue[testPayload]{
+				Data: testPayload{
+					Key: "foo",
+				},
+				Valid: true,
+			},
+			want: []byte(`{"key":"foo"}`),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := tt.value.Value()
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.want, v)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add a custom sql types to serialyse types in JSON

Relates to https://github.com/upfluence/ecommerce-server/pull/96#discussion_r920377681

### What are the observable changes?

New sql types to encode/decode json object in a db.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

Bumping to go 1.18