### PR TITLE
backend/postgres: Accept pre written CACertFile in the config

### DIFF
--- a/backend/postgres/config_test.go
+++ b/backend/postgres/config_test.go
@@ -15,6 +15,10 @@ func TestDSN(t *testing.T) {
 			c:   Config{DBName: "foobar", SSLMode: VerifyFull},
 			dsn: "postgres://localhost:5432/foobar?sslmode=verify-full",
 		},
+		{
+			c:   Config{DBName: "foobar", CACertFile: "foobar"},
+			dsn: "postgres://localhost:5432/foobar?sslmode=verify-ca&sslrootcert=foobar",
+		},
 	} {
 		dsn, err := tt.c.DSN()
 


### PR DESCRIPTION
### What does this PR do?

In order to avoid writing multiple time the certificate we let the user pass a file handle directly

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
