### PR TITLE
x/sqlbuilder: Handle the ON CONFLICT option on the InsertStatement 

### DIFF
--- a/x/sqlbuilder/insert_statement.go
+++ b/x/sqlbuilder/insert_statement.go
@@ -2,10 +2,102 @@ package sqlbuilder
 
 import (
 	"fmt"
-	"strings"
+	"io"
 
 	"github.com/upfluence/sql"
 )
+
+type OnConflictTarget struct {
+	Fields []Marker
+	Where  PredicateClause
+}
+
+func (oct *OnConflictTarget) Clone() *OnConflictTarget {
+	if oct == nil {
+		return nil
+	}
+
+	var w PredicateClause
+
+	if oct.Where != nil {
+		w = oct.Where.Clone()
+	}
+
+	return &OnConflictTarget{
+		Fields: cloneMarkers(oct.Fields),
+		Where:  w,
+	}
+}
+
+func (oct *OnConflictTarget) WriteTo(qw QueryWriter, vs map[string]interface{}) error {
+	io.WriteString(qw, "(")
+
+	for i, f := range oct.Fields {
+		io.WriteString(qw, columnName(f))
+
+		if i < len(oct.Fields)-1 {
+			io.WriteString(qw, ", ")
+		}
+	}
+
+	io.WriteString(qw, ")")
+
+	if oct.Where != nil {
+		io.WriteString(qw, " WHERE ")
+
+		return oct.Where.WriteTo(qw, vs)
+	}
+
+	return nil
+}
+
+type OnConflictAction interface {
+	isOnConflictAction()
+	Clone() OnConflictAction
+
+	QuerySegment
+}
+
+type Update []Marker
+
+func (ms Update) Clone() OnConflictAction {
+	return Update(cloneMarkers([]Marker(ms)))
+}
+
+func (Update) isOnConflictAction() {}
+func (ms Update) WriteTo(qw QueryWriter, vs map[string]interface{}) error {
+	io.WriteString(qw, "UPDATE SET ")
+
+	return writeUpdateClauses(ms, qw, vs)
+}
+
+type nothing struct{}
+
+func (nothing) Clone() OnConflictAction { return Nothing }
+func (nothing) isOnConflictAction()     {}
+func (nothing) WriteTo(qw QueryWriter, _ map[string]interface{}) error {
+	_, err := io.WriteString(qw, "NOTHING")
+
+	return err
+}
+
+var Nothing nothing
+
+type OnConflictClause struct {
+	Target *OnConflictTarget
+	Action OnConflictAction
+}
+
+func (occ *OnConflictClause) Clone() *OnConflictClause {
+	if occ == nil {
+		return nil
+	}
+
+	return &OnConflictClause{
+		Target: occ.Target.Clone(),
+		Action: occ.Action.Clone(),
+	}
+}
 
 type InsertStatement struct {
 	Table string
@@ -13,6 +105,7 @@ type InsertStatement struct {
 	Fields []Marker
 
 	Returning *sql.Returning
+	OnConfict *OnConflictClause
 }
 
 func (is InsertStatement) Clone() InsertStatement {
@@ -28,58 +121,66 @@ func (is InsertStatement) Clone() InsertStatement {
 		Table:     is.Table,
 		Fields:    cloneMarkers(is.Fields),
 		Returning: r,
+		OnConfict: is.OnConfict.Clone(),
 	}
 }
 
 func (is InsertStatement) buildQuery(qvs map[string]interface{}) (string, []interface{}, error) {
-	var (
-		b strings.Builder
-
-		ks = make([]string, len(is.Fields))
-		vs = make([]interface{}, len(is.Fields))
-	)
+	var qw queryWriter
 
 	if len(is.Fields) == 0 {
 		return "", nil, errNoMarkers
 	}
 
-	fmt.Fprintf(&b, "INSERT INTO %s(", is.Table)
+	fmt.Fprintf(&qw, "INSERT INTO %s(", is.Table)
 
 	for i, f := range is.Fields {
-		b.WriteString(columnName(f))
+		qw.WriteString(columnName(f))
 
 		if i < len(is.Fields)-1 {
-			b.WriteString(", ")
-		}
-
-		ks[i] = f.Binding()
-	}
-
-	b.WriteString(") VALUES (")
-
-	for i := range is.Fields {
-		fmt.Fprintf(&b, "$%d", i+1)
-
-		if i < len(is.Fields)-1 {
-			b.WriteString(", ")
+			qw.WriteString(", ")
 		}
 	}
 
-	b.WriteRune(')')
+	qw.WriteString(") VALUES (")
 
-	for i, k := range ks {
-		v, ok := qvs[k]
+	for i, f := range is.Fields {
+		v, ok := qvs[f.Binding()]
 
 		if !ok {
-			return "", nil, ErrMissingKey{Key: k}
+			return "", nil, ErrMissingKey{Key: f.Binding()}
 		}
 
-		vs[i] = v
+		qw.WriteString(qw.RedeemVariable(v))
+
+		if i < len(is.Fields)-1 {
+			qw.WriteString(", ")
+		}
+	}
+
+	qw.WriteRune(')')
+
+	if oc := is.OnConfict; oc != nil {
+		qw.WriteString(" ON CONFLICT ")
+
+		if t := oc.Target; t != nil {
+			if err := t.WriteTo(&qw, qvs); err != nil {
+				return "", nil, err
+			}
+
+			qw.WriteString(" ")
+		}
+
+		qw.WriteString("DO ")
+
+		if err := oc.Action.WriteTo(&qw, qvs); err != nil {
+			return "", nil, err
+		}
 	}
 
 	if is.Returning != nil {
-		vs = append(vs, is.Returning)
+		qw.vs = append(qw.vs, is.Returning)
 	}
 
-	return b.String(), vs, nil
+	return qw.String(), qw.vs, nil
 }

--- a/x/sqlbuilder/insert_statement_test.go
+++ b/x/sqlbuilder/insert_statement_test.go
@@ -54,6 +54,37 @@ func TestInsertQuery(t *testing.T) {
 			stmt: "INSERT INTO foo(buz) VALUES ($1)",
 			args: []interface{}{1, &sql.Returning{Field: "bar"}},
 		},
+		{
+			name: "with on conflict nothing",
+			is: InsertStatement{
+				Table:  "foo",
+				Fields: []Marker{Column("buz")},
+				OnConfict: &OnConflictClause{
+					Action: Nothing,
+				},
+			},
+			vs:   map[string]interface{}{"buz": 1},
+			stmt: "INSERT INTO foo(buz) VALUES ($1) ON CONFLICT DO NOTHING",
+			args: []interface{}{1},
+		},
+		{
+			name: "with on conflict update",
+			is: InsertStatement{
+				Table:  "foo",
+				Fields: []Marker{Column("buz")},
+				OnConfict: &OnConflictClause{
+					Target: &OnConflictTarget{
+						Fields: []Marker{Column("buz")},
+					},
+					Action: Update{
+						Column("bar"),
+					},
+				},
+			},
+			vs:   map[string]interface{}{"buz": 1, "bar": 2},
+			stmt: "INSERT INTO foo(buz) VALUES ($1) ON CONFLICT (buz) DO UPDATE SET bar = $2",
+			args: []interface{}{1, 2},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			stmt, args, err := tt.is.Clone().buildQuery(tt.vs)

--- a/x/sqlbuilder/upserter/upserter.go
+++ b/x/sqlbuilder/upserter/upserter.go
@@ -34,6 +34,8 @@ type Statement struct {
 	Returning *sql.Returning
 
 	Mode Mode
+
+	QueryConstrained bool
 }
 
 func (s Statement) mode() Mode {
@@ -52,6 +54,7 @@ type Upserter struct {
 	ExecuteTxOptions []sql.ExecuteTxOption
 }
 
+func (u *Upserter) queryer() sql.Queryer { return u.DB }
 func (u *Upserter) executeTx(ctx context.Context, fn func(sql.Queryer) error) error {
 	return sql.ExecuteTx(
 		ctx,
@@ -72,6 +75,7 @@ type queryerTxExecutor struct {
 	sql.Queryer
 }
 
+func (qte *queryerTxExecutor) queryer() sql.Queryer { return qte.Queryer }
 func (qte *queryerTxExecutor) executeTx(ctx context.Context, fn func(sql.Queryer) error) error {
 	switch err := fn(qte); err {
 	case nil, sql.ErrRollback:


### PR DESCRIPTION
### What does this PR do?

This PR adds the support for `ON CONFLICT` syntax that is supported by postgres as well as sqlite3.

It allows some optimization in the `upserter` package to avoid having to deal with explicit txs and multiple  network roundtrips.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
