### PR TITLE
x/sqlbuilder: Handle iter.Seq in the In clause

### DIFF
--- a/x/migration/fs_source.go
+++ b/x/migration/fs_source.go
@@ -1,4 +1,4 @@
-// +build go1.16
+//go:build go1.16
 
 package migration
 

--- a/x/sqlbuilder/predicate_clause.go
+++ b/x/sqlbuilder/predicate_clause.go
@@ -318,7 +318,7 @@ func (bc *basicClause) WriteTo(w QueryWriter, vs map[string]interface{}) error {
 	return bc.fn(w, vv, bc.m.ToSQL())
 }
 
-func writeInClause(w QueryWriter, vv interface{}, k string) error {
+func writeInClauseBasic(w QueryWriter, vv interface{}, k string) error {
 	v := reflect.ValueOf(vv)
 
 	if k := v.Kind(); k != reflect.Slice && k != reflect.Array {

--- a/x/sqlbuilder/predicate_clause_go_1_22.go
+++ b/x/sqlbuilder/predicate_clause_go_1_22.go
@@ -1,0 +1,7 @@
+//go:build !go1.23
+
+package sqlbuilder
+
+func writeInClause(w QueryWriter, vv interface{}, k string) error {
+	return writeInClauseBasic(w, vv, k)
+}

--- a/x/sqlbuilder/predicate_clause_go_1_23.go
+++ b/x/sqlbuilder/predicate_clause_go_1_23.go
@@ -1,0 +1,22 @@
+//go:build go1.23
+
+package sqlbuilder
+
+import "reflect"
+
+func writeInClause(w QueryWriter, vv interface{}, k string) error {
+	v := reflect.ValueOf(vv)
+	t := v.Type()
+
+	if t.CanSeq() && t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
+		var vs []interface{}
+
+		for v := range v.Seq() {
+			vs = append(vs, v.Interface())
+		}
+
+		return writeInClauseBasic(w, vs, k)
+	}
+
+	return writeInClauseBasic(w, vv, k)
+}

--- a/x/sqlbuilder/predicate_clause_go_1_23_test.go
+++ b/x/sqlbuilder/predicate_clause_go_1_23_test.go
@@ -1,0 +1,24 @@
+//go:build go1.23
+
+package sqlbuilder
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeqIN(t *testing.T) {
+	var w queryWriter
+
+	err := StaticIn(
+		Column("foo"),
+		slices.Values([]int{4, 5, 6}),
+	).WriteTo(&w, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "foo IN ($1, $2, $3)", w.String())
+	assert.Equal(t, []any{4, 5, 6}, w.vs)
+}


### PR DESCRIPTION
### What does this PR do?

We wont get bitten by the `maps.Keys` anymore 😅 

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
