### PR TITLE
x/sqlbuilder: Add QueryRow API to the InsertExecer type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upfluence/sql
 
-go 1.21
+go 1.23
 
 require (
 	github.com/lib/pq v1.10.9

--- a/x/sqlbuilder/insert_statement_test.go
+++ b/x/sqlbuilder/insert_statement_test.go
@@ -85,6 +85,32 @@ func TestInsertQuery(t *testing.T) {
 			stmt: "INSERT INTO foo(buz) VALUES ($1) ON CONFLICT (buz) DO UPDATE SET bar = $2",
 			args: []interface{}{1, 2},
 		},
+		{
+			name: "with returning + isQuery",
+			is: InsertStatement{
+				Table:     "foo",
+				Fields:    []Marker{Column("buz")},
+				Returning: &sql.Returning{Field: "buz"},
+				isQuery:   true,
+			},
+			vs:   map[string]interface{}{"buz": 1},
+			stmt: "INSERT INTO foo(buz) VALUES ($1) RETURNING buz",
+			args: []interface{}{1},
+		},
+		{
+			name: "with returnings ",
+			is: InsertStatement{
+				Table:  "foo",
+				Fields: []Marker{Column("buz")},
+				Returnings: []*sql.Returning{
+					{Field: "buz"},
+					{Field: "bar"},
+				},
+			},
+			vs:   map[string]interface{}{"buz": 1},
+			stmt: "INSERT INTO foo(buz) VALUES ($1) RETURNING buz, bar",
+			args: []interface{}{1},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			stmt, args, err := tt.is.Clone().buildQuery(tt.vs)

--- a/x/sqlbuilder/query_builder.go
+++ b/x/sqlbuilder/query_builder.go
@@ -52,6 +52,24 @@ type InsertExecer struct {
 	Statement    InsertStatement
 }
 
+type errScanner struct {
+	error
+}
+
+func (es errScanner) Scan(...interface{}) error {
+	return es.error
+}
+
+func (ie *InsertExecer) QueryRow(ctx context.Context, qvs map[string]interface{}) sql.Scanner {
+	stmt, vs, err := ie.stmt.buildQuery(qvs)
+
+	if err != nil {
+		return errScanner{error: err}
+	}
+
+	return ie.qb.QueryRow(ctx, stmt, vs...)
+}
+
 func (ie *InsertExecer) MultiExec(ctx context.Context, vvs []map[string]interface{}, qvs map[string]interface{}) (sql.Result, error) {
 	stmt, vs, err := ie.Statement.buildQueries(vvs, qvs)
 

--- a/x/sqlbuilder/query_builder.go
+++ b/x/sqlbuilder/query_builder.go
@@ -61,13 +61,16 @@ func (es errScanner) Scan(...interface{}) error {
 }
 
 func (ie *InsertExecer) QueryRow(ctx context.Context, qvs map[string]interface{}) sql.Scanner {
-	stmt, vs, err := ie.stmt.buildQuery(qvs)
+	stmt := ie.Statement
+	stmt.isQuery = true
+
+	sstmt, vs, err := stmt.buildQuery(qvs)
 
 	if err != nil {
 		return errScanner{error: err}
 	}
 
-	return ie.qb.QueryRow(ctx, stmt, vs...)
+	return ie.qb.QueryRow(ctx, sstmt, vs...)
 }
 
 func (ie *InsertExecer) MultiExec(ctx context.Context, vvs []map[string]interface{}, qvs map[string]interface{}) (sql.Result, error) {


### PR DESCRIPTION
### What does this PR do?

In order to leverage complex insert queries with complex returning cluases having a `QueryRow` API should go a long way

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- x ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
